### PR TITLE
fix: package.json semver for "sonos" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/bencevans/sonos-cli",
   "dependencies": {
     "minimist": "^1.2.0",
-    "sonos": "^0.13.0",
+    "sonos": "^0.15.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
For versions greater than or equal to 0.1.0, but less than 1.0.0, the caret (^) adopts the same behavior as a tilde (~) and will allow flexibility in patch versions (only). My change will allow npm to correctly pull down the latest stable release (**v0.15.0**) for the [`sonos`](https://www.npmjs.com/package/sonos) (i.e. [bencevans](https://github.com/bencevans)/[node-sonos](https://github.com/bencevans/node-sonos) repo) dependency.

**[ [npm documentation](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) ]**
![image](https://user-images.githubusercontent.com/9957358/26987090-094d0114-4cff-11e7-912e-15a8fbf60ee9.png)
