### PR TITLE
getZoneController: handle errors when called async

### DIFF
--- a/lib/getZoneController.js
+++ b/lib/getZoneController.js
@@ -11,7 +11,9 @@ const getZoneController = async (timeout, zoneName, callback) => {
   })
 
   if (!group) {
-    return callback(new Error('Unable to find specified zone'))
+    const error = new Error('Unable to find specified zone')
+    if (callback) return callback(error)
+    throw error
   }
 
   const controller = group.ZoneGroupMember.find(member => {


### PR DESCRIPTION
Prevents a "callback is not a function" error. Fixes #45 